### PR TITLE
Add warnings for invalid commands

### DIFF
--- a/src/main/kotlin/com/github/dnsv/relativeactions/input/KeyProcessor.kt
+++ b/src/main/kotlin/com/github/dnsv/relativeactions/input/KeyProcessor.kt
@@ -5,12 +5,14 @@ import com.github.dnsv.relativeactions.keymap.Position
 import com.github.dnsv.relativeactions.keymap.RelativeAction
 import com.github.dnsv.relativeactions.relativeaction.RelativeActionProcessor
 import com.github.dnsv.relativeactions.util.LineRange
+import com.github.dnsv.relativeactions.util.Notify
 import com.intellij.openapi.editor.Editor
 
 class KeyProcessor(
     private val editor: Editor,
 ) {
-    private val lineBuffer = StringBuilder()
+    private val commandInput = StringBuilder()
+    private val lineRangeInput = StringBuilder()
     private var position: Position = Position.INITIAL
     private var relativeAction: RelativeAction = RelativeAction.MOVE
 
@@ -21,8 +23,10 @@ class KeyProcessor(
      * @return `true` if the command was executed, `false` otherwise.
      */
     fun executeKey(char: Char): Boolean {
+        commandInput.append(char)
+
         when {
-            char.isDigit() || (char == LineRange.SEPARATOR && char !in lineBuffer) -> lineBuffer.append(char)
+            char.isDigit() || (char == LineRange.SEPARATOR && char !in lineRangeInput) -> lineRangeInput.append(char)
 
             Position.containsKey(char) -> position = Position.getValue(char)
 
@@ -30,17 +34,58 @@ class KeyProcessor(
 
             // The action is executed only when a direction key is pressed
             Direction.containsKey(char) -> {
-                executeAction(Direction.getValue(char))
+                executeCommand(Direction.getValue(char))
                 return true
+            }
+
+            else -> {
+                // A warning is shown and the char is removed from the command input if it doesn't match any binding.
+                // The user can then continue with the command as if nothing happened.
+                commandInput.deleteCharAt(commandInput.length - 1)
+                Notify.warning(editor, "No binding for key: '$char'.")
             }
         }
 
         return false
     }
 
-    private fun executeAction(direction: Direction) {
-        val lineRange = LineRange.create(editor, lineBuffer.toString(), direction)
+    private fun executeCommand(direction: Direction) {
+        if (!validateCommand(direction)) return
+
+        val lineRange = LineRange.create(editor, lineRangeInput.toString(), direction)
 
         RelativeActionProcessor.executeAction(editor, lineRange, position, relativeAction)
     }
+
+    private fun validateCommand(direction: Direction): Boolean =
+        when {
+            direction == Direction.BOTH && relativeAction == RelativeAction.MOVE -> {
+                val key = Direction.getKey(direction)
+                Notify.warning(
+                    editor,
+                    "Invalid command '$commandInput': '$key' (bidirectional) cannot be used for movement.",
+                )
+                false
+            }
+
+            position == Position.BEGINNING && relativeAction != RelativeAction.MOVE -> {
+                val key = Position.getKey(position)
+                Notify.warning(
+                    editor,
+                    "Invalid command '$commandInput': '$key' (beginning of line) can only be used for movement.",
+                )
+                false
+            }
+
+            position == Position.END && relativeAction != RelativeAction.MOVE -> {
+                val key = Position.getKey(position)
+                Notify.warning(
+                    editor,
+                    "Invalid command '$commandInput': '$key' (end of line) can only be used for movement.",
+                )
+                false
+            }
+
+            else -> true
+        }
 }

--- a/src/main/kotlin/com/github/dnsv/relativeactions/keymap/AbstractKeymapEnum.kt
+++ b/src/main/kotlin/com/github/dnsv/relativeactions/keymap/AbstractKeymapEnum.kt
@@ -11,6 +11,8 @@ abstract class AbstractKeymapEnum<T : Enum<T>> {
 
     fun getValue(key: Char): T = getKeymap().getValue(key)
 
+    fun getKey(value: T): Char? = getKeymap().entries.firstOrNull { it.value == value }?.key
+
     fun invalidateCache() {
         keymapCache = null
     }

--- a/src/main/kotlin/com/github/dnsv/relativeactions/session/SessionManager.kt
+++ b/src/main/kotlin/com/github/dnsv/relativeactions/session/SessionManager.kt
@@ -1,6 +1,6 @@
 package com.github.dnsv.relativeactions.session
 
-import com.github.dnsv.relativeactions.util.NotificationService
+import com.github.dnsv.relativeactions.util.Notify
 import com.intellij.openapi.editor.Editor
 
 /**
@@ -9,13 +9,11 @@ import com.intellij.openapi.editor.Editor
 object SessionManager : SessionListener {
     private var session: Session? = null
 
-    override fun onSessionEnd() {
-        end()
-    }
+    override fun onSessionEnd() = end()
 
     fun start(editor: Editor) {
         if (editor.caretModel.caretCount > 1) {
-            NotificationService.info(editor.project, "Relative Actions can't run while multiple carets are active.")
+            Notify.warning(editor, "Relative Actions can't run while multiple carets are active.")
             return
         }
 
@@ -24,9 +22,7 @@ object SessionManager : SessionListener {
         session = Session(editor, this)
     }
 
-    fun restart(editor: Editor) {
-        start(editor)
-    }
+    fun restart(editor: Editor) = start(editor)
 
     fun end() {
         session?.dispose()

--- a/src/main/kotlin/com/github/dnsv/relativeactions/util/Notify.kt
+++ b/src/main/kotlin/com/github/dnsv/relativeactions/util/Notify.kt
@@ -2,25 +2,22 @@ package com.github.dnsv.relativeactions.util
 
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 
-object NotificationService {
+object Notify {
     const val NOTIFICATION_TITLE = "Relative Actions"
 
     private val notificationGroup = NotificationGroupManager.getInstance().getNotificationGroup("relative-actions")
 
-    fun info(
-        project: Project?,
+    fun warning(
+        editor: Editor,
         message: String,
-    ) {
-        createNotification(project, message, NotificationType.INFORMATION)
-    }
+    ) = createNotification(editor.project, message, NotificationType.WARNING)
 
     private fun createNotification(
         project: Project?,
         message: String,
         type: NotificationType,
-    ) {
-        notificationGroup.createNotification(NOTIFICATION_TITLE, message, type).notify(project)
-    }
+    ) = notificationGroup.createNotification(NOTIFICATION_TITLE, message, type).notify(project)
 }

--- a/src/test/kotlin/com/github/dnsv/relativeactions/CommandValidationTest.kt
+++ b/src/test/kotlin/com/github/dnsv/relativeactions/CommandValidationTest.kt
@@ -1,0 +1,52 @@
+package com.github.dnsv.relativeactions
+
+import com.github.dnsv.relativeactions.util.BaseTestCase
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class CommandValidationTest : BaseTestCase() {
+    @Test
+    fun `test no binding for key`() {
+        makeEditor("")
+
+        performCommand("g")
+
+        Assertions.assertEquals("No binding for key: 'g'.", getLastNotification().content)
+    }
+
+    @Test
+    fun `test cannot use bidirectional key for movement`() {
+        makeEditor("")
+
+        performCommand("3b")
+
+        Assertions.assertEquals(
+            "Invalid command '3b': 'b' (bidirectional) cannot be used for movement.",
+            getLastNotification().content,
+        )
+    }
+
+    @Test
+    fun `test cannot use beginning of line key with an action`() {
+        makeEditor("")
+
+        performCommand("wcl")
+
+        Assertions.assertEquals(
+            "Invalid command 'wcl': 'w' (beginning of line) can only be used for movement.",
+            getLastNotification().content,
+        )
+    }
+
+    @Test
+    fun `test cannot use end of line key with an action`() {
+        makeEditor("")
+
+        performCommand("edl")
+
+        Assertions.assertEquals(
+            "Invalid command 'edl': 'e' (end of line) can only be used for movement.",
+            getLastNotification().content,
+        )
+    }
+}

--- a/src/test/kotlin/com/github/dnsv/relativeactions/RelativeActionCommentTest.kt
+++ b/src/test/kotlin/com/github/dnsv/relativeactions/RelativeActionCommentTest.kt
@@ -6,6 +6,7 @@ import com.intellij.lang.LanguageCommenters
 import com.intellij.openapi.editor.LogicalPosition
 import com.intellij.openapi.fileTypes.PlainTextLanguage
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.CsvSource
@@ -141,6 +142,7 @@ class RelativeActionCommentTest : BaseTestCase() {
         assertCaretPosition(expectedPosition)
     }
 
+    @Test
     fun `test comment text one line shortcut`() {
         makeEditor("1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n")
         moveCaret(LogicalPosition(4, 0)) // At "5\n"

--- a/src/test/kotlin/com/github/dnsv/relativeactions/RelativeActionCopyTest.kt
+++ b/src/test/kotlin/com/github/dnsv/relativeactions/RelativeActionCopyTest.kt
@@ -2,6 +2,7 @@ package com.github.dnsv.relativeactions
 
 import com.github.dnsv.relativeactions.util.BaseTestCase
 import com.intellij.openapi.editor.LogicalPosition
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 
@@ -62,6 +63,7 @@ class RelativeActionCopyTest : BaseTestCase() {
         assertClipboard(expectedText)
     }
 
+    @Test
     fun `test copy text one line shortcut`() {
         makeEditor("1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n")
         moveCaret(LogicalPosition(4, 0)) // At "5\n"

--- a/src/test/kotlin/com/github/dnsv/relativeactions/RelativeActionCutTest.kt
+++ b/src/test/kotlin/com/github/dnsv/relativeactions/RelativeActionCutTest.kt
@@ -2,6 +2,7 @@ package com.github.dnsv.relativeactions
 
 import com.github.dnsv.relativeactions.util.BaseTestCase
 import com.intellij.openapi.editor.LogicalPosition
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.CsvSource
@@ -110,6 +111,7 @@ class RelativeActionCutTest : BaseTestCase() {
         assertCaretPosition(expectedPosition)
     }
 
+    @Test
     fun `test cut text one line shortcut`() {
         makeEditor("1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n")
         moveCaret(LogicalPosition(4, 0)) // At "5\n"

--- a/src/test/kotlin/com/github/dnsv/relativeactions/RelativeActionDeleteTest.kt
+++ b/src/test/kotlin/com/github/dnsv/relativeactions/RelativeActionDeleteTest.kt
@@ -2,6 +2,7 @@ package com.github.dnsv.relativeactions
 
 import com.github.dnsv.relativeactions.util.BaseTestCase
 import com.intellij.openapi.editor.LogicalPosition
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.CsvSource
@@ -106,6 +107,7 @@ class RelativeActionDeleteTest : BaseTestCase() {
         assertCaretPosition(expectedPosition)
     }
 
+    @Test
     fun `test delete text one line shortcut`() {
         makeEditor("1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n")
         moveCaret(LogicalPosition(4, 0)) // At "5\n"

--- a/src/test/kotlin/com/github/dnsv/relativeactions/RelativeActionMoveTest.kt
+++ b/src/test/kotlin/com/github/dnsv/relativeactions/RelativeActionMoveTest.kt
@@ -2,6 +2,7 @@ package com.github.dnsv.relativeactions
 
 import com.github.dnsv.relativeactions.util.BaseTestCase
 import com.intellij.openapi.editor.LogicalPosition
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -78,6 +79,7 @@ class RelativeActionMoveTest : BaseTestCase() {
         assertCaretPosition(expectedPosition)
     }
 
+    @Test
     fun `test move caret ignores separator`() {
         makeEditor("0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n")
 

--- a/src/test/kotlin/com/github/dnsv/relativeactions/RelativeActionSelectTest.kt
+++ b/src/test/kotlin/com/github/dnsv/relativeactions/RelativeActionSelectTest.kt
@@ -2,6 +2,7 @@ package com.github.dnsv.relativeactions
 
 import com.github.dnsv.relativeactions.util.BaseTestCase
 import com.intellij.openapi.editor.LogicalPosition
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.CsvSource
@@ -101,6 +102,7 @@ class RelativeActionSelectTest : BaseTestCase() {
         assertCaretPosition(expectedPosition)
     }
 
+    @Test
     fun `test select text one line shortcut`() {
         makeEditor("1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n")
         moveCaret(LogicalPosition(4, 0)) // At "5\n"

--- a/src/test/kotlin/com/github/dnsv/relativeactions/util/BaseTestCase.kt
+++ b/src/test/kotlin/com/github/dnsv/relativeactions/util/BaseTestCase.kt
@@ -1,5 +1,7 @@
 package com.github.dnsv.relativeactions.util
 
+import com.intellij.notification.ActionCenter
+import com.intellij.notification.Notification
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.LogicalPosition
@@ -48,6 +50,8 @@ abstract class BaseTestCase {
     protected fun getEditor(): Editor = myFixture.editor
 
     protected fun simulateTyping(input: String) = input.forEach { char -> myFixture.type(char) }
+
+    protected fun getLastNotification(): Notification = ActionCenter.getNotifications(myFixture.project).last()
 
     protected fun performCommand(command: String) {
         myFixture.performEditorAction("ActivateRelativeActions")


### PR DESCRIPTION
This PR adds warnings (notifications) for invalid commands:
- No binding for key.
- Using 'b' (bidirectional) for movement.
- Using 'w' (beginning of line) with an action.
- Using 'e' (end of line) with an action.